### PR TITLE
Fixes #42 sn3218 extension not available

### DIFF
--- a/src/extensions/extensions.cc
+++ b/src/extensions/extensions.cc
@@ -35,6 +35,7 @@ IMPLEMENT_EXPORT_INIT(extensions) {
   INIT(mcp23017);
   INIT(pcf8574);
   INIT(pcf8591);
+  INIT(sn3218);
   INIT(sr595);
   INIT(pca9685);
 }


### PR DESCRIPTION
Loading `sn3218` extention with which all [18 documented extentions](https://github.com/eugeneware/wiring-pi/blob/master/DOCUMENTATION.md#extensions) are now exported.