### PR TITLE
Fixes #43 How to release a wiringPiI2CSetup() file descriptor

### DIFF
--- a/src/wiringPiI2C.cc
+++ b/src/wiringPiI2C.cc
@@ -1,5 +1,6 @@
 #include "wiringPiI2C.h"
 #include <wiringPiI2C.h>
+#include <unistd.h>
 
 DECLARE(wiringPiI2CRead);
 DECLARE(wiringPiI2CReadReg8);
@@ -9,6 +10,7 @@ DECLARE(wiringPiI2CWriteReg8);
 DECLARE(wiringPiI2CWriteReg16);
 DECLARE(wiringPiI2CSetupInterface);
 DECLARE(wiringPiI2CSetup);
+DECLARE(wiringPiI2CClose);
 
 // Func : int wiringPiI2CRead (int fd);
 // Simple device read. Some devices present data when you read them without having to do any register transactions.
@@ -188,6 +190,26 @@ IMPLEMENT(wiringPiI2CSetup) {
   SCOPE_CLOSE(INT32(res));
 }
 
+// Func : void wiringPiI2CClose(const int fd)
+// Description : This closes opened I2C file descriptor
+// fd is file descriptor returned either from wiringPiI2CSetup or wiringPiI2CSetupInterface
+
+IMPLEMENT(wiringPiI2CClose) {
+  SCOPE_OPEN();
+
+  SET_ARGUMENT_NAME(0, fd);
+
+  CHECK_ARGUMENTS_LENGTH_EQUAL(1);
+
+  CHECK_ARGUMENT_TYPE_INT32(0);
+
+  int fd = GET_ARGUMENT_AS_INT32(0);
+
+  ::close(fd);
+
+  SCOPE_CLOSE(UNDEFINED());
+}
+
 IMPLEMENT_EXPORT_INIT(wiringPiI2C) {
   EXPORT_FUNCTION(wiringPiI2CRead);
   EXPORT_FUNCTION(wiringPiI2CReadReg8);
@@ -197,4 +219,5 @@ IMPLEMENT_EXPORT_INIT(wiringPiI2C) {
   EXPORT_FUNCTION(wiringPiI2CWriteReg16);
   EXPORT_FUNCTION(wiringPiI2CSetupInterface);
   EXPORT_FUNCTION(wiringPiI2CSetup);
+  EXPORT_FUNCTION(wiringPiI2CClose);
 }

--- a/src/wiringPiSPI.cc
+++ b/src/wiringPiSPI.cc
@@ -1,10 +1,12 @@
 #include "wiringPiSPI.h"
 #include <wiringPiSPI.h>
+#include <unistd.h>
 
 DECLARE(wiringPiSPIGetFd);
 DECLARE(wiringPiSPIDataRW);
 DECLARE(wiringPiSPISetup);
 DECLARE(wiringPiSPISetupMode);
+DECLARE(wiringPiSPIClose);
 
 // Func : int wiringPiSPIGetFd(int channel)
 
@@ -98,9 +100,30 @@ IMPLEMENT(wiringPiSPISetupMode) {
   SCOPE_CLOSE(INT32(res));
 }
 
+// Func : void wiringPiSPIClose(const int fd)
+// Description : This closes opened SPI file descriptor
+// fd is file descriptor returned either from wiringPiSPISetup or wiringPiSPISetupMode
+
+IMPLEMENT(wiringPiSPIClose) {
+  SCOPE_OPEN();
+
+  SET_ARGUMENT_NAME(0, fd);
+
+  CHECK_ARGUMENTS_LENGTH_EQUAL(1);
+
+  CHECK_ARGUMENT_TYPE_INT32(0);
+
+  int fd = GET_ARGUMENT_AS_INT32(0);
+
+  ::close(fd);
+
+  SCOPE_CLOSE(UNDEFINED());
+}
+
 IMPLEMENT_EXPORT_INIT(wiringPiSPI) {
   EXPORT_FUNCTION(wiringPiSPIGetFd);
   EXPORT_FUNCTION(wiringPiSPIDataRW);
   EXPORT_FUNCTION(wiringPiSPISetup);
   EXPORT_FUNCTION(wiringPiSPISetupMode);
+  EXPORT_FUNCTION(wiringPiSPIClose);
 }


### PR DESCRIPTION
I've searched `WiringPi`'s `src` for functions that [`open`](https://github.com/WiringPi/WiringPi/search?utf8=%E2%9C%93&q=open) a file descriptor and found that only `SPI` and `I2C` interfaces opens file descriptor by making call to `open` for which there is no corresponding disposing function, since in C/C++ it is expected `close` to be used like @nekuz0r pointed in #43.

The search showed that currently `wiirngPiI2cSetup` makes a call to `wiringPiI2CSetupInterface` which dose an [`open`](https://github.com/WiringPi/WiringPi/blob/9a8f8bee5df60061645918231110a7c2e4d3fa6b/wiringPi/wiringPiI2C.c#L203) and `wiringPiSPISetup` makes a call to `wiirngPiSPISetupMode` which dose an [`open`](https://github.com/WiringPi/WiringPi/blob/9a8f8bee5df60061645918231110a7c2e4d3fa6b/wiringPi/wiringPiSPI.c#L106).

I've decided to add separate closing function for each communication interface instead of one core `close` for both since `Serial` has it's own `serialClose` and some one may potentially decide to close the opened file descriptor by making a call to that `open` function instead of `serialClose` ...

So with this PR I'm adding:

- `wiringPiI2CClose` for releasing opened file descriptor from `wiringPiI2CSetup` or  `wiringPiI2CSetupInterface`.

- `wiringPiSPIClose` for releasing opened file descriptor from `wiringPiSPISetup` or  `wiringPiSPISetupMode`.

Both functions share a redundant implementation but having one separate implementation in `nodemodule` `namespace` would require manually writing function's implementation and exporting under different name using `v8` members which in my opinion contrasts with the whole idea of `addon.h` beeing declaritive and unified framework for writing `WiringPi`'s node addon ...